### PR TITLE
Fix: Handle NullPointerException for 'testValue' in AuthController.java

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -23,6 +23,10 @@ public class AuthController {
         try {
             // This will throw NullPointerException if 'key' is not present or null
             String testValue = (String) payload.get("key");
+            if (testValue == null) {
+                logger.warn("Received /login request with null 'key' in payload.");
+                return ResponseEntity.status(400).body("Error: 'key' cannot be null in the request payload.");
+            }
             int length = testValue.length();
             return ResponseEntity.ok("Length: " + length);
         } catch (NullPointerException e) {


### PR DESCRIPTION
### Problem Description

The `AuthController.java` currently throws a `NullPointerException` if the `key` field in the request payload is null or missing. This results in a generic `500 Internal Server Error` which is not user-friendly and doesn't provide specific information about the missing or null field.

### Solution Approach

To address this, a null check has been implemented for `testValue` immediately after it's retrieved from the `payload` map. If `testValue` is found to be null, the application will now return a `400 Bad Request` status code with a more descriptive error message, clearly indicating that the `key` in the payload cannot be null.

### Changes Made

- Added `if (testValue == null)` check after `String testValue = (String) payload.get("key");`
- If `testValue` is null, a `ResponseEntity.status(400).body("Error: 'key' cannot be null in the request payload.")` is returned.
- A `logger.warn` message is added for better logging when `key` is null.

### Testing Notes

To test this fix:
1. Send a POST request to `/api/login` without the `key` field in the request body.
2. Verify that the response status code is `400`.
3. Verify that the response body contains the message: "Error: 'key' cannot be null in the request payload."
4. Send a POST request to `/api/login` with the `key` field present and a non-null value.
5. Verify that the request is processed successfully and returns the expected `200 OK` response.