### PR TITLE
Fix: NullPointerException in AuthController

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -21,19 +21,15 @@ public class AuthController {
         logger.info("Received /login request with payload: {}", payload);
 
         try {
-            // This will throw NullPointerException if 'key' is not present or null
             String testValue = (String) payload.get("key");
-            int length = testValue.length();
-            return ResponseEntity.ok("Length: " + length);
-        } catch (NullPointerException e) {
-            // Log to application logger
-            logger.error("❌ NullPointerException occurred in /login", e);
-
-            // Also log raw trace to stderr
-            System.err.println("❌ NullPointerException stack trace:");
-            e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Null value encountered");
+            
+            if (testValue != null) {
+                int length = testValue.length();
+                return ResponseEntity.ok("Length: " + length);
+            } else {
+                logger.error("❌ 'key' not found or is null in the payload for /login request.");
+                return ResponseEntity.badRequest().body("Error: 'key' not found or is null in the payload.");
+            }
         } catch (Exception e) {
             logger.error("❌ Unexpected exception occurred in /login", e);
             System.err.println("❌ Unexpected exception stack trace:");


### PR DESCRIPTION
This PR fixes a NullPointerException that occurs when the 'key' field in the payload is null or not present in the /api/login endpoint. 

**Problem:**
Previously, the code would throw a NullPointerException if `payload.get("key")` returned null, as it directly called `.length()` on the result without a null check.

**Solution:**
Added a null check for `testValue` after retrieving it from the payload. If `testValue` is null, a `ResponseEntity.badRequest()` is returned with an appropriate error message instead of throwing a NullPointerException.

**Jira Ticket:** [20]