### PR TITLE
Fix: Handle null and type casting for 'key' in AuthController.java

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -21,24 +21,29 @@ public class AuthController {
         logger.info("Received /login request with payload: {}", payload);
 
         try {
-            // This will throw NullPointerException if 'key' is not present or null
-            String testValue = (String) payload.get("key");
+            // Retrieve the value for 'key'
+            Object keyValue = payload.get("key");
+
+            // Explicitly check for null
+            if (keyValue == null) {
+                logger.error("❌ 'key' is missing or null in the payload for /login request.");
+                return ResponseEntity.badRequest().body("Error: 'key' is required and cannot be null.");
+            }
+
+            // Attempt to cast and use the value
+            if (!(keyValue instanceof String)) {
+                logger.error("❌ ClassCastException occurred for 'key' in /login: value is not a String. Received type: {}", keyValue.getClass().getName());
+                return ResponseEntity.badRequest().body("Error: Value for 'key' must be a string.");
+            }
+
+            String testValue = (String) keyValue;
             int length = testValue.length();
             return ResponseEntity.ok("Length: " + length);
-        } catch (NullPointerException e) {
-            // Log to application logger
-            logger.error("❌ NullPointerException occurred in /login", e);
 
-            // Also log raw trace to stderr
-            System.err.println("❌ NullPointerException stack trace:");
-            e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Null value encountered");
-        } catch (Exception e) {
+        } catch (Exception e) { // Catch any other unexpected exceptions
             logger.error("❌ Unexpected exception occurred in /login", e);
             System.err.println("❌ Unexpected exception stack trace:");
             e.printStackTrace(System.err);
-
             return ResponseEntity.status(500).body("Error: Unexpected error occurred");
         }
     }


### PR DESCRIPTION
## Problem Description

The original code in `AuthController.java` for the `/login` endpoint was susceptible to `NullPointerException` and `ClassCastException` if the `key` field in the request payload was missing, null, or not a string.

## Solution Approach

Implemented explicit null checks for the `key` value retrieved from the payload and verified its type using `instanceof`. This ensures that the application handles cases where the `key` is absent or malformed gracefully, returning appropriate bad request responses instead of throwing runtime exceptions.

## Changes Made

- Added `null` check for `keyValue` after retrieving it from the payload.
- Added `instanceof String` check for `keyValue` to ensure it's a String before casting.
- Modified error logging to be more specific regarding missing/null keys and type mismatches.
- Changed the `catch` block to handle a general `Exception` to catch any other unexpected issues and provide a generic error message.

## Testing Notes

The fix can be tested by sending requests to `/api/login` with:
- A payload missing the `key` field.
- A payload with `key` as `null`.
- A payload with `key` as a non-string value (e.g., a number or boolean).
- A valid payload with `key` as a string to ensure existing functionality is preserved.