### PR TITLE
Fix: NullPointerException in /api/login endpoint due to missing or null 'key' in payload.

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus; // Import HttpStatus
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,24 +22,24 @@ public class AuthController {
         logger.info("Received /login request with payload: {}", payload);
 
         try {
-            // This will throw NullPointerException if 'key' is not present or null
             String testValue = (String) payload.get("key");
+
+            if (testValue == null) {
+                logger.warn("The 'key' field in the payload is missing or null for /api/login request.");
+                return ResponseEntity.badRequest().body("Error: 'key' field is missing or null in the request body.");
+            }
+
             int length = testValue.length();
             return ResponseEntity.ok("Length: " + length);
-        } catch (NullPointerException e) {
-            // Log to application logger
-            logger.error("❌ NullPointerException occurred in /login", e);
-
-            // Also log raw trace to stderr
-            System.err.println("❌ NullPointerException stack trace:");
+        } catch (ClassCastException e) {
+            logger.error("❌ ClassCastException occurred in /login: 'key' value is not a String", e);
+            System.err.println("❌ ClassCastException stack trace:");
             e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Null value encountered");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Error: 'key' value must be a string.");
         } catch (Exception e) {
             logger.error("❌ Unexpected exception occurred in /login", e);
             System.err.println("❌ Unexpected exception stack trace:");
             e.printStackTrace(System.err);
-
             return ResponseEntity.status(500).body("Error: Unexpected error occurred");
         }
     }


### PR DESCRIPTION
This PR fixes a `NullPointerException` occurring in the `/api/login` endpoint due to a missing or null 'key' in the request payload.

**Problem Description:**
The `AuthController.java` file at line 26 was throwing a `NullPointerException` when `testValue.length()` was called, because `testValue` was `null`. This happened when the incoming request payload's "key" field was either missing or had a null value, or if its type was not a String.

**Solution Approach:**
1. Added a null check for `testValue` after retrieving it from the payload. If `testValue` is null, a `400 Bad Request` response is returned.
2. Implemented `try-catch` blocks to handle `ClassCastException` if the "key" value is not a `String`, returning a `400 Bad Request`.
3. Included a general `Exception` catch for any other unexpected errors, returning a `500 Internal Server Error`.
4. Added detailed logging for different scenarios to aid in debugging.

**Changes Made:**
- Modified `AuthController.java` to include null checks and type checks for the 'key' field in the request payload.
- Replaced `NullPointerException` catch with `ClassCastException` and a generic `Exception` catch.
- Enhanced error responses with more specific messages and appropriate HTTP status codes.

**Testing Notes:**
- Manual testing: Send requests to `/api/login` with:
  - A valid `{"key": "someValue"}` payload (expected: 200 OK).
  - A `{"key": null}` payload (expected: 400 Bad Request).
  - A `{"key": 123}` payload (expected: 400 Bad Request).
  - An empty payload `{}` (expected: 400 Bad Request).

**Related Issues/Tickets:**
Closes #26