### PR TITLE
Fix: NullPointerException in AuthController.java

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -21,19 +21,14 @@ public class AuthController {
         logger.info("Received /login request with payload: {}", payload);
 
         try {
-            // This will throw NullPointerException if 'key' is not present or null
             String testValue = (String) payload.get("key");
-            int length = testValue.length();
-            return ResponseEntity.ok("Length: " + length);
-        } catch (NullPointerException e) {
-            // Log to application logger
-            logger.error("❌ NullPointerException occurred in /login", e);
-
-            // Also log raw trace to stderr
-            System.err.println("❌ NullPointerException stack trace:");
-            e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Null value encountered");
+            if (testValue != null) {
+                int length = testValue.length();
+                return ResponseEntity.ok("Length: " + length);
+            } else {
+                logger.warn("testValue is null. Cannot get length.");
+                return ResponseEntity.badRequest().body("Error: 'key' parameter is null or missing.");
+            }
         } catch (Exception e) {
             logger.error("❌ Unexpected exception occurred in /login", e);
             System.err.println("❌ Unexpected exception stack trace:");


### PR DESCRIPTION
### Problem Description
A `java.lang.NullPointerException` is occurring in the `payment-backend` service, specifically within the `AuthController.java` file at line 26, due to an attempt to invoke `String.length()` on a null variable named `testValue`. This is affecting the `/login` endpoint (previously referred to as `nullPointerTest`).

### Solution Approach
Implemented a null check for `testValue` before attempting to call `testValue.length()`. If `testValue` is null, a `400 Bad Request` response is returned, indicating that the 'key' parameter is missing or null.

### Changes Made
Modified `src/main/java/com/example/payments/controller/AuthController.java`:
- Added an `if (testValue != null)` condition around the `testValue.length()` call.
- Replaced the `NullPointerException` catch block with a more general `Exception` catch block to handle any unexpected exceptions.
- In the `else` block (when `testValue` is null), a `ResponseEntity.badRequest()` is returned with an appropriate error message.

### Testing Notes
To test this fix, send a POST request to `/api/login` without the 'key' in the request body, or with 'key' having a null value. The expected response should be a 400 Bad Request instead of a 500 Internal Server Error (NullPointerException).

### Related Issue
Fixes #27