### PR TITLE
Fix: NullPointerException in AuthController.java

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -21,20 +21,14 @@ public class AuthController {
         logger.info("Received /login request with payload: {}", payload);
 
         try {
-            // This will throw NullPointerException if 'key' is not present or null
             String testValue = (String) payload.get("key");
+            if (testValue == null) {
+                logger.warn("Received /login request with missing or null 'key' in payload. Returning bad request.");
+                return ResponseEntity.badRequest().body("Error: 'key' parameter is missing or null.");
+            }
             int length = testValue.length();
             return ResponseEntity.ok("Length: " + length);
-        } catch (NullPointerException e) {
-            // Log to application logger
-            logger.error("❌ NullPointerException occurred in /login", e);
-
-            // Also log raw trace to stderr
-            System.err.println("❌ NullPointerException stack trace:");
-            e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Null value encountered");
-        } catch (Exception e) {
+        } catch (Exception e) { // Catch generic Exception to handle other potential issues gracefully
             logger.error("❌ Unexpected exception occurred in /login", e);
             System.err.println("❌ Unexpected exception stack trace:");
             e.printStackTrace(System.err);


### PR DESCRIPTION
Problem Description:
A `NullPointerException` was occurring in the `/api/login` endpoint of the `payment-backend` service. This was due to `testValue` being null when `payload.get("key")` returned null, and then `testValue.length()` was called.

Solution Approach:
Added a null check for `testValue` before calling `length()`. If `testValue` is null, a 400 Bad Request is returned to indicate invalid input.

Changes Made:
Modified `src/main/java/com/example/payments/controller/AuthController.java` to include a null check for the `testValue` variable. Removed the `NullPointerException` catch block as it's no longer needed with the explicit null check.

Testing Notes:
Tested by sending requests to `/api/login` with and without the "key" parameter, and with "key" having a null value.
- Request with `{"key": "someValue"}`: Returns 200 OK with length.
- Request with `{"someOtherKey": "someValue"}`: Returns 400 Bad Request.
- Request with `{"key": null}`: Returns 400 Bad Request.

Related Issue: N/A