### PR TITLE
Fix: NullPointerException in payment-backend (Jira-29)

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -23,6 +23,13 @@ public class AuthController {
         try {
             // This will throw NullPointerException if 'key' is not present or null
             String testValue = (String) payload.get("key");
+            
+            // Fix: Add null check for testValue
+            if (testValue == null) {
+                logger.error("❌ NullPointerException occurred in /login: 'key' not found or is null in payload");
+                return ResponseEntity.status(400).body("Error: 'key' not found or is null in the request payload");
+            }
+            
             int length = testValue.length();
             return ResponseEntity.ok("Length: " + length);
         } catch (NullPointerException e) {


### PR DESCRIPTION
This PR fixes the NullPointerException in the payment-backend service as reported in JIRA ticket ID 29.

### Problem Description:
A `NullPointerException` was occurring in the `AuthController.java` when the `key` field was missing or null in the request payload, specifically in the `/api/login` endpoint. This caused the application to crash.

### Solution Approach:
Added a null check for the `testValue` variable, which is retrieved from the request payload. If `testValue` is null, a `400 Bad Request` error is returned to the client, preventing the `NullPointerException`.

### Changes Made:
- Modified `src/main/java/com/example/payments/controller/AuthController.java` to add a null check for `payload.get("key")`.

### Testing Notes:
To test this fix, send a request to `/api/login` with a payload that:
1. Does not contain the `key` field.
2. Contains the `key` field with a `null` value.

In both cases, the API should return a `400 Bad Request` with an appropriate error message, instead of a `500 Internal Server Error` due to `NullPointerException`.