### PR TITLE
Fix: NullPointerException in AuthController.java

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -21,19 +21,14 @@ public class AuthController {
         logger.info("Received /login request with payload: {}", payload);
 
         try {
-            // This will throw NullPointerException if 'key' is not present or null
             String testValue = (String) payload.get("key");
-            int length = testValue.length();
-            return ResponseEntity.ok("Length: " + length);
-        } catch (NullPointerException e) {
-            // Log to application logger
-            logger.error("❌ NullPointerException occurred in /login", e);
-
-            // Also log raw trace to stderr
-            System.err.println("❌ NullPointerException stack trace:");
-            e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Null value encountered");
+            if (testValue != null) {
+                int length = testValue.length();
+                return ResponseEntity.ok("Length: " + length);
+            } else {
+                logger.warn("\'key\' parameter is missing or null in /login request.");
+                return ResponseEntity.badRequest().body("Error: \'key\' parameter is missing or null.");
+            }
         } catch (Exception e) {
             logger.error("❌ Unexpected exception occurred in /login", e);
             System.err.println("❌ Unexpected exception stack trace:");


### PR DESCRIPTION
**Problem Description:**
A `java.lang.NullPointerException` was occurring in the `nullPointerTest` method of `AuthController.java` when processing requests to the `/api/login` endpoint. Specifically, `testValue.length()` was called on a null `testValue` because `payload.get("key")` returned null if the "key" was missing or explicitly null in the request payload. This led to 500 Internal Server Errors.

**Solution Approach:**
Implemented a null check for `testValue` before attempting to call `length()` on it. If `testValue` is null, a `400 Bad Request` response is returned to the client, providing a more appropriate error message and preventing the `NullPointerException`. The original `NullPointerException` catch block has been removed as it is no longer necessary.

**Changes Made:**
- Modified `src/main/java/com/example/payments/controller/AuthController.java`:
  - Added a `null` check for `testValue`.
  - If `testValue` is `null`, return `ResponseEntity.badRequest().body("Error: 'key' parameter is missing or null.");`.
  - Removed the specific `catch (NullPointerException e)` block as the null check handles the error gracefully.

**Testing Notes:**
- Manual testing: Sending requests to `/api/login`:
  - With a valid `key` in the payload: Expect 200 OK with length.
  - Without a `key` in the payload: Expect 400 Bad Request.
  - With `key: null` in the payload: Expect 400 Bad Request.

**Related Issue:**
- Bug report provided by the user.