### PR TITLE
Fix: NullPointerException in AuthController.java

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -21,19 +21,14 @@ public class AuthController {
         logger.info("Received /login request with payload: {}", payload);
 
         try {
-            // This will throw NullPointerException if 'key' is not present or null
-            String testValue = (String) payload.get("key");
-            int length = testValue.length();
-            return ResponseEntity.ok("Length: " + length);
-        } catch (NullPointerException e) {
-            // Log to application logger
-            logger.error("❌ NullPointerException occurred in /login", e);
-
-            // Also log raw trace to stderr
-            System.err.println("❌ NullPointerException stack trace:");
-            e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Null value encountered");
+            String testValue = (String) payload.get("key"); 
+            if (testValue != null) {
+                int length = testValue.length();
+                return ResponseEntity.ok("Length: " + length);
+            } else {
+                logger.warn("Received /login request with 'key' as null or missing in payload.");
+                return ResponseEntity.badRequest().body("Error: 'key' parameter is missing or null.");
+            }
         } catch (Exception e) {
             logger.error("❌ Unexpected exception occurred in /login", e);
             System.err.println("❌ Unexpected exception stack trace:");


### PR DESCRIPTION
### Problem Description

Issue #32 reports a `NullPointerException` occurring in `AuthController.java` when the `key` parameter in the request payload is null or missing.

### Solution Approach

Implemented a null check for `testValue` before attempting to call `.length()` on it. If `testValue` is null, a `ResponseEntity.badRequest()` is returned to indicate a missing or null `key` parameter. This prevents the `NullPointerException` and provides a more informative error response.

### Changes Made

- Modified `src/main/java/com/example/payments/controller/AuthController.java` to include a null check for the `testValue` variable.
- Added a `logger.warn` statement for when the `key` is null or missing.
- Returned a `ResponseEntity.badRequest()` with an appropriate error message when `key` is null or missing.
- Removed the `try-catch` block for `NullPointerException` as it is now handled by the null check.

### Testing Notes

Manual testing was performed by sending requests with and without the `key` parameter, and with a null `key` value, to confirm the fix addresses the `NullPointerException` and returns the expected responses.