### PR TITLE
Fix NullPointerException in AuthController.java (JIRA-36)

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -21,8 +21,11 @@ public class AuthController {
         logger.info("Received /login request with payload: {}", payload);
 
         try {
-            // This will throw NullPointerException if 'key' is not present or null
             String testValue = (String) payload.get("key");
+            if (testValue == null) {
+                logger.error("❌ 'key' is missing or null in the request payload.");
+                return ResponseEntity.badRequest().body("Error: 'key' is required and cannot be null.");
+            }
             int length = testValue.length();
             return ResponseEntity.ok("Length: " + length);
         } catch (NullPointerException e) {


### PR DESCRIPTION
### Problem Description:
The `AuthController.java` was throwing a `NullPointerException` when the "key" was missing or null in the request payload, specifically at the line `int length = testValue.length();`.

### Solution Approach:
Added a null check for `testValue` before attempting to get its length. If `testValue` is null, it now returns a `badRequest` response with an appropriate error message and logs the error.

### Changes Made:
*   Added `if (testValue == null)` block.
*   Logged an error message when `key` is missing or null.
*   Returned `ResponseEntity.badRequest()` when `key` is missing or null.

### Testing Notes:
Tested by sending requests with and without the "key" in the payload. The `NullPointerException` is resolved, and appropriate error messages are returned for missing/null keys.
