### PR TITLE
Fix: Handle NullPointerException in AuthController.java

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -20,26 +20,13 @@ public class AuthController {
     public ResponseEntity<String> nullPointerTest(@RequestBody Map<String, Object> payload) {
         logger.info("Received /login request with payload: {}", payload);
 
-        try {
-            // This will throw NullPointerException if 'key' is not present or null
-            String testValue = (String) payload.get("key");
+        String testValue = (String) payload.get("key");
+        if (testValue != null) {
             int length = testValue.length();
             return ResponseEntity.ok("Length: " + length);
-        } catch (NullPointerException e) {
-            // Log to application logger
-            logger.error("❌ NullPointerException occurred in /login", e);
-
-            // Also log raw trace to stderr
-            System.err.println("❌ NullPointerException stack trace:");
-            e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Null value encountered");
-        } catch (Exception e) {
-            logger.error("❌ Unexpected exception occurred in /login", e);
-            System.err.println("❌ Unexpected exception stack trace:");
-            e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Unexpected error occurred");
+        } else {
+            // Provide a more descriptive error for the client
+            return ResponseEntity.badRequest().body("Error: 'key' is missing or null in the request payload.");
         }
     }
 }


### PR DESCRIPTION
Problem Description:
A `NullPointerException` was occurring in the `payment-backend` service, specifically within the `nullPointerTest` endpoint (`/api/login`) of the `AuthController.java` class. The error logs indicated "❌ NullPointerException stack trace:" when the 'key' was missing or null in the request payload.

Solution Approach:
The fix involves adding a null check for the `testValue` retrieved from the payload. If `testValue` is null, a `badRequest` response is returned to the client with a more descriptive error message, preventing the `NullPointerException`.

Changes Made:
- Modified the `nullPointerTest` method in `src/main/java/com/example/payments/controller/AuthController.java`.
- Replaced the `try-catch` block for `NullPointerException` with a direct null check for `testValue`.
- If `testValue` is null, a `400 Bad Request` is returned with an informative message.
- If `testValue` is not null, the length is calculated and returned as before.

Testing Notes:
Manual testing should involve sending requests to `/api/login`:
- With a valid `key` in the payload (e.g., `{"key": "some_value"}`).
- Without the `key` in the payload (e.g., `{}`).
- With `key` present but its value as `null` (e.g., `{"key": null}`).

Related Issue:
Jira Ticket ID: 37