### PR TITLE
Fix: Handle NullPointerException in AuthController

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -21,19 +21,14 @@ public class AuthController {
         logger.info("Received /login request with payload: {}", payload);
 
         try {
-            // This will throw NullPointerException if 'key' is not present or null
             String testValue = (String) payload.get("key");
-            int length = testValue.length();
+            int length = 0; // Initialize with a default value
+            if (testValue != null) {
+                length = testValue.length();
+            } else {
+                logger.warn("The 'key' field was missing or null in the payload.");
+            }
             return ResponseEntity.ok("Length: " + length);
-        } catch (NullPointerException e) {
-            // Log to application logger
-            logger.error("❌ NullPointerException occurred in /login", e);
-
-            // Also log raw trace to stderr
-            System.err.println("❌ NullPointerException stack trace:");
-            e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Null value encountered");
         } catch (Exception e) {
             logger.error("❌ Unexpected exception occurred in /login", e);
             System.err.println("❌ Unexpected exception stack trace:");


### PR DESCRIPTION
This PR fixes a NullPointerException that occurs when the 'key' field is missing or null in the payload for the /api/login endpoint.

**Problem Description:**
The original code directly called `.length()` on `testValue` without checking if `testValue` was null, leading to a NullPointerException if the 'key' field was absent or null in the incoming JSON payload.

**Solution Approach:**
Introduced a null check for `testValue` before attempting to get its length. If `testValue` is null, the `length` is initialized to 0, and a warning is logged to indicate the missing 'key' field.

**Changes Made:**
- Modified `src/main/java/com/example/payments/controller/AuthController.java` to include a null check for `testValue`.
- Added a logger warning for cases where the 'key' field is missing or null.
- Removed the `NullPointerException` catch block as it's no longer needed for this specific scenario.

**Testing Notes:**
- Tested with a payload missing the 'key' field: The application now logs a warning and returns 'Length: 0' instead of crashing.
- Tested with a payload containing the 'key' field: The application behaves as expected, returning the correct length.