### PR TITLE
Fix: NullPointerException in AuthController.java

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -20,21 +20,18 @@ public class AuthController {
     public ResponseEntity<String> nullPointerTest(@RequestBody Map<String, Object> payload) {
         logger.info("Received /login request with payload: {}", payload);
 
+        String testValue = (String) payload.get("key");
+
+        // Add null check for testValue
+        if (testValue == null) {
+            logger.warn("Received /login request with 'key' as null or missing in payload: {}", payload);
+            return ResponseEntity.badRequest().body("Error: 'key' is a required field and cannot be null.");
+        }
+
         try {
-            // This will throw NullPointerException if 'key' is not present or null
-            String testValue = (String) payload.get("key");
             int length = testValue.length();
             return ResponseEntity.ok("Length: " + length);
-        } catch (NullPointerException e) {
-            // Log to application logger
-            logger.error("❌ NullPointerException occurred in /login", e);
-
-            // Also log raw trace to stderr
-            System.err.println("❌ NullPointerException stack trace:");
-            e.printStackTrace(System.err);
-
-            return ResponseEntity.status(500).body("Error: Null value encountered");
-        } catch (Exception e) {
+        } catch (Exception e) { // Catch any other unforeseen exceptions
             logger.error("❌ Unexpected exception occurred in /login", e);
             System.err.println("❌ Unexpected exception stack trace:");
             e.printStackTrace(System.err);


### PR DESCRIPTION
This PR fixes a NullPointerException that occurred in the `nullPointerTest` method within `AuthController.java` when the 'key' field was missing or null in the request payload.

Changes include:
- Added a null check for `testValue` (derived from 'key' in payload).
- Returns a `400 Bad Request` with a specific error message if 'key' is null or missing.
- Improves error handling and user experience by providing clearer feedback for invalid input.

Resolves: [JIRA_TICKET_ID]