### PR TITLE
Fix: NullPointerException in AuthController.java

### DIFF
--- a/src/main/java/com/example/payments/controller/AuthController.java
+++ b/src/main/java/com/example/payments/controller/AuthController.java
@@ -21,24 +21,22 @@ public class AuthController {
         logger.info("Received /login request with payload: {}", payload);
 
         try {
-            // This will throw NullPointerException if 'key' is not present or null
             String testValue = (String) payload.get("key");
+            if (testValue == null) {
+                logger.warn("Payload missing 'key' or 'key' has null value.");
+                return ResponseEntity.badRequest().body("Error: 'key' is required and cannot be null.");
+            }
             int length = testValue.length();
             return ResponseEntity.ok("Length: " + length);
         } catch (NullPointerException e) {
-            // Log to application logger
             logger.error("❌ NullPointerException occurred in /login", e);
-
-            // Also log raw trace to stderr
             System.err.println("❌ NullPointerException stack trace:");
             e.printStackTrace(System.err);
-
             return ResponseEntity.status(500).body("Error: Null value encountered");
         } catch (Exception e) {
             logger.error("❌ Unexpected exception occurred in /login", e);
             System.err.println("❌ Unexpected exception stack trace:");
             e.printStackTrace(System.err);
-
             return ResponseEntity.status(500).body("Error: Unexpected error occurred");
         }
     }


### PR DESCRIPTION
### Problem Description

The `nullPointerTest` method in `AuthController.java` throws a `NullPointerException` if the 'key' is missing or null in the request payload. This is because `testValue.length()` is called without ensuring that `testValue` is not null.

### Solution Approach

Implemented a null check for `testValue` immediately after retrieving it from the payload. If `testValue` is null, the method now returns a `ResponseEntity.badRequest()` with an informative error message, preventing the `NullPointerException`.

### Changes Made

Modified `src/main/java/com/example/payments/controller/AuthController.java`:
- Added an `if (testValue == null)` condition to check for nullity of the `testValue`.
- If `testValue` is null, a `ResponseEntity.badRequest()` is returned with the message "Error: 'key' is required and cannot be null."

### Testing Notes

To test this fix, send a POST request to `/api/login` with:
- A payload missing the 'key': `{}`
- A payload with 'key' as null: `{"key": null}`

Both scenarios should now return a 400 Bad Request with the specified error message, instead of a 500 Internal Server Error due to `NullPointerException`.

### Related Issues/Tickets

N/A